### PR TITLE
複数カラムのナチュラルキーについて、Spannerでの思いを馳せた

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ func main() {
 	ts := NewTweetStore(tc, sc)
 	tcs := NewTweetCompositeKeyStore(tc, sc)
 	ths := NewTweetHashKeyStore(tc, sc)
+	tus := NewTweetUniqueIndexStore(tc, sc)
 
 	endCh := make(chan error)
 	go func() {
@@ -108,6 +109,28 @@ func main() {
 				endCh <- err
 			}
 			fmt.Printf("TWEET_HASHKEY_INSERT ID = %s\n", id)
+		}
+	}()
+
+	go func() {
+		for {
+			ctx := context.Background()
+			id := uuid.New().String()
+			tweet := &TweetUniqueIndex{
+				ID:         id,
+				TweetID:    uuid.New().String(),
+				Author:     getAuthor(),
+				Content:    uuid.New().String(),
+				Favos:      getAuthors(),
+				Sort:       rand.Int(),
+				CreatedAt:  time.Now(),
+				UpdatedAt:  time.Now(),
+				CommitedAt: spanner.CommitTimestamp,
+			}
+			if err := tus.Insert(ctx, tweet); err != nil {
+				endCh <- err
+			}
+			fmt.Printf("TWEET_UNIQUEINDEX_INSERT ID = %s\n", id)
 		}
 	}()
 

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ func main() {
 
 	ts := NewTweetStore(tc, sc)
 	tcs := NewTweetCompositeKeyStore(tc, sc)
+	ths := NewTweetHashKeyStore(tc, sc)
 
 	endCh := make(chan error)
 	go func() {
@@ -52,7 +53,7 @@ func main() {
 			ctx := context.Background()
 			id := uuid.New().String()
 			if err := ts.Insert(ctx, &Tweet{
-				ID:         uuid.New().String(),
+				ID:         id,
 				Author:     getAuthor(),
 				Content:    uuid.New().String(),
 				Favos:      getAuthors(),
@@ -72,7 +73,7 @@ func main() {
 			ctx := context.Background()
 			id := uuid.New().String()
 			tweet := &TweetCompositeKey{
-				ID:         uuid.New().String(),
+				ID:         id,
 				Author:     getAuthor(),
 				Content:    uuid.New().String(),
 				Favos:      getAuthors(),
@@ -85,6 +86,28 @@ func main() {
 				endCh <- err
 			}
 			fmt.Printf("TWEET_COMPOSITEKEY_INSERT ID = %s, Author = %s\n", id, tweet.Author)
+		}
+	}()
+
+	go func() {
+		for {
+			ctx := context.Background()
+			author := getAuthor()
+			id := ths.NewKey(uuid.New().String(), author)
+			tweet := &TweetHashKey{
+				ID:         id,
+				Author:     getAuthor(),
+				Content:    uuid.New().String(),
+				Favos:      getAuthors(),
+				Sort:       rand.Int(),
+				CreatedAt:  time.Now(),
+				UpdatedAt:  time.Now(),
+				CommitedAt: spanner.CommitTimestamp,
+			}
+			if err := ths.Insert(ctx, tweet); err != nil {
+				endCh <- err
+			}
+			fmt.Printf("TWEET_HASHKEY_INSERT ID = %s\n", id)
 		}
 	}()
 

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ func main() {
 	}
 
 	ts := NewTweetStore(tc, sc)
+	tcs := NewTweetCompositeKeyStore(tc, sc)
 
 	endCh := make(chan error)
 	go func() {
@@ -63,6 +64,27 @@ func main() {
 				endCh <- err
 			}
 			fmt.Printf("TWEET_INSERT ID = %s\n", id)
+		}
+	}()
+
+	go func() {
+		for {
+			ctx := context.Background()
+			id := uuid.New().String()
+			tweet := &TweetCompositeKey{
+				ID:         uuid.New().String(),
+				Author:     getAuthor(),
+				Content:    uuid.New().String(),
+				Favos:      getAuthors(),
+				Sort:       rand.Int(),
+				CreatedAt:  time.Now(),
+				UpdatedAt:  time.Now(),
+				CommitedAt: spanner.CommitTimestamp,
+			}
+			if err := tcs.Insert(ctx, tweet); err != nil {
+				endCh <- err
+			}
+			fmt.Printf("TWEET_COMPOSITEKEY_INSERT ID = %s, Author = %s\n", id, tweet.Author)
 		}
 	}()
 

--- a/tweet_compositekey_store.go
+++ b/tweet_compositekey_store.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"cloud.google.com/go/trace"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"google.golang.org/api/iterator"
+)
+
+// TweetCompositeKeyStore is TweetTable Functions
+type TweetCompositeKeyStore interface {
+	TableName() string
+	Insert(ctx context.Context, tweet *TweetCompositeKey) error
+	Get(ctx context.Context, key spanner.Key) (*TweetCompositeKey, error)
+	Query(ctx context.Context, limit int) ([]*TweetCompositeKey, error)
+}
+
+var tweetCompositeKeyStore TweetCompositeKeyStore
+
+// NewTweetCompositeKeyStore is New TweetStore
+func NewTweetCompositeKeyStore(tc *trace.Client, sc *spanner.Client) TweetCompositeKeyStore {
+	if tweetCompositeKeyStore == nil {
+		tweetCompositeKeyStore = &defaultTweetCompositeKeyStore{
+			tc: tc,
+			sc: sc,
+		}
+	}
+	return tweetCompositeKeyStore
+}
+
+// TweetCompositeKey is TweetTable Row
+type TweetCompositeKey struct {
+	ID         string `spanner:"Id"`
+	Author     string
+	Content    string
+	Favos      []string
+	Sort       int
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+	CommitedAt time.Time
+}
+
+type defaultTweetCompositeKeyStore struct {
+	tc *trace.Client
+	sc *spanner.Client
+}
+
+// TableName is return Table Name for Spanner
+func (s *defaultTweetCompositeKeyStore) TableName() string {
+	return "TweetCompositeKey"
+}
+
+// Insert is Insert to Tweet
+func (s *defaultTweetCompositeKeyStore) Insert(ctx context.Context, tweet *TweetCompositeKey) error {
+	ts := s.tc.NewSpan("/tweetCompositeKey/insert")
+	defer ts.Finish()
+
+	m, err := spanner.InsertStruct(s.TableName(), tweet)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	om, err := NewOperationInsertMutation(uuid.New().String(), "INSERT", tweet.ID, s.TableName(), tweet)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	ms := []*spanner.Mutation{
+		m,
+		om,
+	}
+
+	_, err = s.sc.Apply(ctx, ms)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
+}
+
+func (s defaultTweetCompositeKeyStore) Get(ctx context.Context, key spanner.Key) (*TweetCompositeKey, error) {
+	ts := s.tc.NewSpan("/tweetCompositeKey/get")
+	defer ts.Finish()
+
+	row, err := s.sc.Single().ReadRow(ctx, s.TableName(), key, []string{"Author", "CommitedAt", "Content", "CreatedAt", "Favos", "Sort", "UpdatedAt"})
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	var tweet TweetCompositeKey
+	row.ToStruct(&tweet)
+	return &tweet, nil
+}
+
+// Query is Tweet を sort_ascで取得する
+func (s *defaultTweetCompositeKeyStore) Query(ctx context.Context, limit int) ([]*TweetCompositeKey, error) {
+	ts := s.tc.NewSpan("/tweetCompositeKey/query")
+	defer ts.Finish()
+
+	iter := s.sc.Single().ReadUsingIndex(ctx, s.TableName(), "sort_asc", spanner.AllKeys(), []string{"Id", "Sort"})
+	defer iter.Stop()
+
+	count := 0
+	tweets := []*TweetCompositeKey{}
+	for {
+		if count >= limit {
+			return tweets, nil
+		}
+		row, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+
+		var tweet TweetCompositeKey
+		row.ToStruct(&tweet)
+		tweets = append(tweets, &tweet)
+		count++
+	}
+
+	return tweets, nil
+}

--- a/tweet_hashkey_store.go
+++ b/tweet_hashkey_store.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"cloud.google.com/go/trace"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"google.golang.org/api/iterator"
+)
+
+// TweetHashKeyStore is TweetTable Functions
+type TweetHashKeyStore interface {
+	TableName() string
+	NewKey(id string, author string) string
+	Insert(ctx context.Context, tweet *TweetHashKey) error
+	Get(ctx context.Context, key spanner.Key) (*TweetHashKey, error)
+	Query(ctx context.Context, limit int) ([]*TweetHashKey, error)
+}
+
+var tweetHashKeyStore TweetHashKeyStore
+
+// NewTweetHashKeyStore is New TweetHashKeyStore
+func NewTweetHashKeyStore(tc *trace.Client, sc *spanner.Client) TweetHashKeyStore {
+	if tweetHashKeyStore == nil {
+		tweetHashKeyStore = &defaultTweetHashKeyStore{
+			tc: tc,
+			sc: sc,
+		}
+	}
+	return tweetHashKeyStore
+}
+
+// TweetHashKey is TweetTable Row
+type TweetHashKey struct {
+	ID         string `spanner:"Id"`
+	Author     string
+	Content    string
+	Favos      []string
+	Sort       int
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+	CommitedAt time.Time
+}
+
+type defaultTweetHashKeyStore struct {
+	tc *trace.Client
+	sc *spanner.Client
+}
+
+// TableName is return Table Name for Spanner
+func (s *defaultTweetHashKeyStore) TableName() string {
+	return "TweetHashKey"
+}
+
+// NewKey is return Table Key
+func (s *defaultTweetHashKeyStore) NewKey(id string, author string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(fmt.Sprintf("%s-_-%s", id, author))))
+}
+
+// Insert is Insert to Tweet
+func (s *defaultTweetHashKeyStore) Insert(ctx context.Context, tweet *TweetHashKey) error {
+	ts := s.tc.NewSpan("/tweetHashKey/insert")
+	defer ts.Finish()
+
+	m, err := spanner.InsertStruct(s.TableName(), tweet)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	om, err := NewOperationInsertMutation(uuid.New().String(), "INSERT", tweet.ID, s.TableName(), tweet)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	ms := []*spanner.Mutation{
+		m,
+		om,
+	}
+
+	_, err = s.sc.Apply(ctx, ms)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
+}
+
+func (s defaultTweetHashKeyStore) Get(ctx context.Context, key spanner.Key) (*TweetHashKey, error) {
+	ts := s.tc.NewSpan("/tweetHashKey/get")
+	defer ts.Finish()
+
+	row, err := s.sc.Single().ReadRow(ctx, s.TableName(), key, []string{"Author", "CommitedAt", "Content", "CreatedAt", "Favos", "Sort", "UpdatedAt"})
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	var tweet TweetHashKey
+	row.ToStruct(&tweet)
+	return &tweet, nil
+}
+
+// Query is Tweet を sort_ascで取得する
+func (s *defaultTweetHashKeyStore) Query(ctx context.Context, limit int) ([]*TweetHashKey, error) {
+	ts := s.tc.NewSpan("/tweetHashKey/query")
+	defer ts.Finish()
+
+	iter := s.sc.Single().ReadUsingIndex(ctx, s.TableName(), "sort_asc", spanner.AllKeys(), []string{"Id", "Sort"})
+	defer iter.Stop()
+
+	count := 0
+	tweets := []*TweetHashKey{}
+	for {
+		if count >= limit {
+			return tweets, nil
+		}
+		row, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+
+		var tweet TweetHashKey
+		row.ToStruct(&tweet)
+		tweets = append(tweets, &tweet)
+		count++
+	}
+
+	return tweets, nil
+}

--- a/tweet_uniqueindex_store.go
+++ b/tweet_uniqueindex_store.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"cloud.google.com/go/trace"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"google.golang.org/api/iterator"
+)
+
+// TweetUniqueIndexStore is TweetTable Functions
+type TweetUniqueIndexStore interface {
+	TableName() string
+	Insert(ctx context.Context, tweet *TweetUniqueIndex) error
+	Get(ctx context.Context, key spanner.Key) (*TweetUniqueIndex, error)
+	Query(ctx context.Context, limit int) ([]*TweetUniqueIndex, error)
+}
+
+var tweetUniqueIndexStore TweetUniqueIndexStore
+
+// NewTweetUniqueIndexStore is New TweetUniqueIndexStore
+func NewTweetUniqueIndexStore(tc *trace.Client, sc *spanner.Client) TweetUniqueIndexStore {
+	if tweetUniqueIndexStore == nil {
+		tweetUniqueIndexStore = &defaultTweetUniqueIndexStore{
+			tc: tc,
+			sc: sc,
+		}
+	}
+	return tweetUniqueIndexStore
+}
+
+// TweetUniqueIndex is TweetTable Row
+type TweetUniqueIndex struct {
+	ID         string `spanner:"Id"`
+	TweetID    string `spanner:"TweetId"`
+	Author     string
+	Content    string
+	Favos      []string
+	Sort       int
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+	CommitedAt time.Time
+}
+
+type defaultTweetUniqueIndexStore struct {
+	tc *trace.Client
+	sc *spanner.Client
+}
+
+// TableName is return Table Name for Spanner
+func (s *defaultTweetUniqueIndexStore) TableName() string {
+	return "TweetUniqueIndex"
+}
+
+// Insert is Insert to Tweet
+func (s *defaultTweetUniqueIndexStore) Insert(ctx context.Context, tweet *TweetUniqueIndex) error {
+	ts := s.tc.NewSpan("/tweetUniqueIndex/insert")
+	defer ts.Finish()
+
+	m, err := spanner.InsertStruct(s.TableName(), tweet)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	om, err := NewOperationInsertMutation(uuid.New().String(), "INSERT", tweet.ID, s.TableName(), tweet)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	ms := []*spanner.Mutation{
+		m,
+		om,
+	}
+
+	_, err = s.sc.Apply(ctx, ms)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
+}
+
+func (s defaultTweetUniqueIndexStore) Get(ctx context.Context, key spanner.Key) (*TweetUniqueIndex, error) {
+	ts := s.tc.NewSpan("/tweetUniqueIndex/get")
+	defer ts.Finish()
+
+	row, err := s.sc.Single().ReadRow(ctx, s.TableName(), key, []string{"Author", "CommitedAt", "Content", "CreatedAt", "Favos", "Sort", "UpdatedAt"})
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	var tweet TweetUniqueIndex
+	row.ToStruct(&tweet)
+	return &tweet, nil
+}
+
+// Query is Tweet を sort_ascで取得する
+func (s *defaultTweetUniqueIndexStore) Query(ctx context.Context, limit int) ([]*TweetUniqueIndex, error) {
+	ts := s.tc.NewSpan("/tweetUniqueIndex/query")
+	defer ts.Finish()
+
+	iter := s.sc.Single().ReadUsingIndex(ctx, s.TableName(), "sort_asc", spanner.AllKeys(), []string{"Id", "Sort"})
+	defer iter.Stop()
+
+	count := 0
+	tweets := []*TweetUniqueIndex{}
+	for {
+		if count >= limit {
+			return tweets, nil
+		}
+		row, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+
+		var tweet TweetUniqueIndex
+		row.ToStruct(&tweet)
+		tweets = append(tweets, &tweet)
+		count++
+	}
+
+	return tweets, nil
+}


### PR DESCRIPTION
## TweetCompositeKey Table

* Id, AuthorをPrimary Keyとして設定したTable

このサンプルではIdがUUIDなので、分散するかもしれないが、AuthorごとにIdがシーケンシャルとかだと微妙そう。
また、途中でKeyに含めるカラムを変更することができないので、Keyが変わると厄介

## TweetHashKey Table

* Id, AuthorからHashを生成してPrimary Keyとして設定したTable

Id, Authorがあれば、Hashを生成してKeyが作れるので、クライアントにはId, Authorさえ渡せばよい。
途中で、Id, Author以外をKeyに入れたくなったとしても、アプリケーション側で対応すればよい。

## TweetUniqueIndex Table

* IdはUUIDでPrimary Keyとして、TweetId, AuthorにUniqueIndexを設定したTable

セカンダリインデックスに対してのクエリはPK取得と比べると遅いのと、STORINGしないと他のカラムが無いので、つらい

Close #16